### PR TITLE
Print the full GL trace on app destroy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wno-unused-function -std=c++1y")
 
 add_definitions(-DOGLW_DEBUG)
+add_definitions(-DOGLW_TRACE)
 add_definitions(-DGLFONS_DEBUG)
 
 # load OGLW library

--- a/oglw/core/app.cpp
+++ b/oglw/core/app.cpp
@@ -22,6 +22,8 @@ App::App(std::string _name, int _width, int _height) :
 App::~App() {
     INFO("App destroy\n");
 
+    printGLTrace();
+
     if (m_textRendering) {
         glfonsDelete(m_fontContext);
     }

--- a/oglw/gl/gl.h
+++ b/oglw/gl/gl.h
@@ -3,13 +3,27 @@
 #include "GL/glew.h"
 #include "GLFW/glfw3.h"
 #include "gl/error.h"
+#include "gl/trace.h"
 
 namespace OGLW {
 
 #ifdef OGLW_DEBUG
-#define GL_CHECK(STMT) do { STMT; _Error::glError(#STMT, __FILE__, __LINE__); } while (0)
+#ifdef OGLW_TRACE
+#define TRACE(STMT, FILE, LINE) _Trace::glTrace(STMT, FILE, LINE);
+#endif
+#define GL_CHECK(STMT) do { \
+    STMT; \
+    TRACE(#STMT, __FILE__, __LINE__); \
+    _Error::glError(#STMT, __FILE__, __LINE__); \
+} while (0)
 #else
 #define GL_CHECK(STMT) STMT;
 #endif
+
+static void printGLTrace() { 
+#ifdef OGLW_TRACE
+    _Trace::printGLTrace();
+#endif
+}
 
 } // OGLW

--- a/oglw/gl/trace.cpp
+++ b/oglw/gl/trace.cpp
@@ -1,0 +1,20 @@
+#include "trace.h"
+#include "log.h"
+
+namespace OGLW {
+namespace _Trace {
+
+static std::vector<GLCall> glCalls;
+
+void glTrace(const char* stmt, const char* fname, int line) {
+    glCalls.push_back({std::string(stmt), std::string(fname), line});
+}
+
+void printGLTrace() {
+    for (auto glCall : glCalls) {
+        INFO("%s:%d %s\n", glCall.fname.c_str(), glCall.line, glCall.stmt.c_str());
+    }
+}
+
+}
+}

--- a/oglw/gl/trace.h
+++ b/oglw/gl/trace.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <vector>
+#include <string>
+
+namespace OGLW {
+namespace _Trace {
+
+struct GLCall {
+    std::string fname;
+    std::string stmt;
+    int line;
+};
+
+void glTrace(const char* stmt, const char* fname, int line);
+
+void printGLTrace();
+
+} // _Trace
+} // OGLW


### PR DESCRIPTION
Misses some GL calls from text rendering